### PR TITLE
Integrate list / regexp dependencies, add autoloads and reformat

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,13 @@ mode.
 
 ## Installation
 
-- There is a dependency on [el-kit](https://github.com/medikoo/el-kit), you will need to place the `el-kit` .el files into your `.emacs` `load-path`. (I'd recommend putting them in their own folder.)
-
-- Add `el-indent.el` to you `.emacs` `load-path`
+Add `el-indent.el` to you `.emacs` `load-path`
 
 ## Usage
+
+To use with a major-mode add `(require 'el-indent)`
+
+(NOTE: adding to MELPA soon, so these instructions will change.)
 
 ### How to use ready configurations ?
 

--- a/el-indent.el
+++ b/el-indent.el
@@ -1,6 +1,11 @@
-;; el-indent.el --- `indent-line-function' configurator
+;;; el-indent.el --- `indent-line-function' configurator
 
+;; Version: 0.2.0
 ;; Author:	Mariusz Nowak <medikoo+el-indent@medikoo.com>
+;; Url: https://github.com/mdeikoo/el-indent
+;; Keywords: major-mode indent
+;; Package-Requires: ((emacs "24.0"))
+;;
 ;; Copyright (C) 2010 Mariusz Nowak <medikoo+el-indent@medikoo.com>
 
 ;; This program is free software; you can redistribute it and/or
@@ -17,8 +22,9 @@
 ;; License along with this program; if not, see <http://www.gnu.org/licenses/>.
 
 ;;; Commentary:
-;;
 ;; See README.
+
+;;; Code:
 
 (eval-when-compile
   (require 'cl-lib))
@@ -194,4 +200,5 @@
 	(el-indent-convert-rules (second rules))
 	rules)
 
-(provide 'el-indent/el-indent)
+(provide 'el-indent)
+;;; el-indent.el ends here


### PR DESCRIPTION
- Removed the dependency on el-kit updated readme.
- Updated the dependency on `copy-list` from `cl.el` (now `cl-copy-list` `cl-lib`)
- Add the dependency requirement for `cl-lib` on compile.
- Add autoload for several functions.
